### PR TITLE
Includes cstring so that memcpy gets defined.

### DIFF
--- a/src/fit_encode.hpp
+++ b/src/fit_encode.hpp
@@ -18,6 +18,7 @@
 #if !defined(FIT_ENCODE_HPP)
 #define FIT_ENCODE_HPP
 
+#include <cstring>
 #include <iosfwd>
 #include <vector>
 #include "fit.hpp"


### PR DESCRIPTION
This is the second patch that solves the compilation issues due to memcpy() not being defined.